### PR TITLE
manifest: set RAM build requirement to 1G ?

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -22,7 +22,7 @@ multi_instance = true
 ldap = false
 sso = false
 disk = "50M"
-ram.build = "50M"
+ram.build = "1G"
 ram.runtime = "50M"
 
 [install]


### PR DESCRIPTION
cf https://forum.yunohost.org/t/unable-to-re-install-send-application-hangs-on-web-ui-at-building/25320

Automatic test's RAM measurement seem to suggest that the build requires 1G~ish RAM